### PR TITLE
:sparkles: HeaderにUsernameを表示 fixes #33

### DIFF
--- a/src/app/ui/auth/logout.jsx
+++ b/src/app/ui/auth/logout.jsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { unauthenticate } from "@/app/lib/auth";
+
+export default function Logout() {
+  return (
+    <>
+      <li className="nav-item">
+        <a className="nav-link" onClick={() => unauthenticate()}>
+          Sign out
+        </a>
+      </li>
+    </>
+  );
+}

--- a/src/app/ui/header-with-login.jsx
+++ b/src/app/ui/header-with-login.jsx
@@ -1,8 +1,8 @@
-"use client";
+import { getCurrentUser } from "@/app/lib/data";
+import Logout from "@/app/ui/auth/logout";
 
-import { unauthenticate } from "@/app/lib/auth";
-
-export default function HeaderWithLogin() {
+export default async function HeaderWithLogin() {
+  const currentUser = await getCurrentUser();
   return (
     <>
       <nav className="navbar navbar-light">
@@ -28,15 +28,14 @@ export default function HeaderWithLogin() {
               </a>
             </li>
             <li className="nav-item">
-              <a className="nav-link" href="#">
-                User Name
+              <a
+                className="nav-link"
+                href={`/profile/${currentUser.user.username}`}
+              >
+                {currentUser.user.username}
               </a>
             </li>
-            <li className="nav-item">
-              <a className="nav-link" onClick={() => unauthenticate()}>
-                Sign out
-              </a>
-            </li>
+            <Logout />
           </ul>
         </div>
       </nav>


### PR DESCRIPTION
## 実施タスク
HeaderにUsernameを表示 fixes #33

## 実施内容
- currentUserを取得して、Usernameを表示するように変更
- logoutのみCCでやる必要があるので、CCとして分割した。

## その他 / 備考
なし