### PR TITLE
:sparkles: 記事が投稿できるようにする fixes #34

### DIFF
--- a/src/app/editor/page.jsx
+++ b/src/app/editor/page.jsx
@@ -1,4 +1,24 @@
+"use client";
+
+import { useFormState } from "react-dom";
+import { useState } from "react";
+import { createArticle } from "@/app/lib/actions";
+
 export default function Page() {
+  const [tags, setTags] = useState([]);
+  const [tag, setTag] = useState("");
+  const createArticleWithTags = createArticle.bind(null, tags);
+  const [error, createAction] = useFormState(createArticleWithTags, "");
+
+  function addTag(tag) {
+    setTags([...tags, tag]);
+    setTag("");
+  }
+
+  function deleteTag(tag) {
+    setTags(tags.filter((element) => element != tag));
+  }
+
   return (
     <>
       <div className="editor-page">
@@ -7,12 +27,13 @@ export default function Page() {
             <div className="col-md-10 offset-md-1 col-xs-12">
               <ul className="error-messages"></ul>
 
-              <form>
+              <form action={createAction}>
                 <fieldset>
                   <fieldset className="form-group">
                     <input
                       type="text"
                       className="form-control form-control-lg"
+                      name="title"
                       placeholder="Article Title"
                     />
                   </fieldset>
@@ -20,6 +41,7 @@ export default function Page() {
                     <input
                       type="text"
                       className="form-control"
+                      name="description"
                       placeholder="What's this article about?"
                     />
                   </fieldset>
@@ -27,25 +49,41 @@ export default function Page() {
                     <textarea
                       className="form-control"
                       rows="8"
+                      name="body"
                       placeholder="Write your article (in markdown)"
                     ></textarea>
                   </fieldset>
+
                   <fieldset className="form-group">
                     <input
                       type="text"
                       className="form-control"
                       placeholder="Enter tags"
+                      value={tag}
+                      onChange={(event) => setTag(event.target.value)}
                     />
                     <div className="tag-list">
-                      <span className="tag-default tag-pill">
-                        {" "}
-                        <i className="ion-close-round"></i> tag{" "}
-                      </span>
+                      {tags.map((tag) => (
+                        <span className="tag-default tag-pill">
+                          {" "}
+                          <i
+                            id={tag}
+                            className="ion-close-round"
+                            onClick={() => deleteTag(tag)}
+                          ></i>{" "}
+                          {tag}{" "}
+                        </span>
+                      ))}
                     </div>
                   </fieldset>
+
+                  <button type="button" onClick={() => addTag(tag)}>
+                    タグを追加
+                  </button>
+
                   <button
                     className="btn btn-lg pull-xs-right btn-primary"
-                    type="button"
+                    type="submit"
                   >
                     Publish Article
                   </button>

--- a/src/app/lib/actions.js
+++ b/src/app/lib/actions.js
@@ -1,0 +1,29 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+export async function createArticle(tags, state, formData) {
+  // console.log(tags);
+  // console.log(formData);
+  console.log(formData.get("title"));
+  try {
+    const response = await fetch(`http://api:3000/api/articles`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${cookies().get("session").value}`,
+        "Content-type": "application/json",
+      },
+      body: JSON.stringify({
+        article: {
+          title: formData.get("title"),
+          description: formData.get("description"),
+          body: formData.get("body"),
+          tagList: tags,
+        },
+      }),
+    });
+  } catch (error) {
+    console.log("記事の生成に失敗しました");
+    // return error;
+  }
+}


### PR DESCRIPTION
## 実施タスク
記事が投稿できるようにする fixes #34

## 実施内容
- フォームのデータを使用できるようにuseFormStateを導入
- bindを使用して、tags配列を一緒に送れるようにした
- それらのデータを使用して、POSTメソッドでfetch

## その他 / 備考
なし