### PR TITLE
:sparkles: 記事を編集できるようにする fixes #35

### DIFF
--- a/src/app/article/[slug]/page.jsx
+++ b/src/app/article/[slug]/page.jsx
@@ -21,6 +21,12 @@ export default async function Page({ params }) {
                 </a>
                 <span className="date">January 20th</span>
               </div>
+              <a
+                href={`/editor/${slug}`}
+                class="btn btn-sm btn-outline-secondary"
+              >
+                <i class="ion-edit"></i> Edit Article
+              </a>
             </div>
           </div>
         </div>

--- a/src/app/editor/[slug]/page.jsx
+++ b/src/app/editor/[slug]/page.jsx
@@ -1,4 +1,29 @@
-export default function Page() {
+"use client";
+
+import { useFormState } from "react-dom";
+import { useState } from "react";
+import { updateArticle } from "@/app/lib/actions";
+
+export default function Page({ params }) {
+  const [tags, setTags] = useState([]);
+  const [tag, setTag] = useState("");
+  const updateArticleWithTags = updateArticle.bind(null, tags);
+  const updateArticleWithSlug = updateArticleWithTags.bind(
+    null,
+    params["slug"]
+  );
+  const [error, updateAction] = useFormState(updateArticleWithSlug, "");
+  console.log(params);
+
+  function addTag(tag) {
+    setTags([...tags, tag]);
+    setTag("");
+  }
+
+  function deleteTag(tag) {
+    setTags(tags.filter((element) => element != tag));
+  }
+
   return (
     <>
       <div className="editor-page">
@@ -7,12 +32,13 @@ export default function Page() {
             <div className="col-md-10 offset-md-1 col-xs-12">
               <ul className="error-messages"></ul>
 
-              <form>
+              <form action={updateAction}>
                 <fieldset>
                   <fieldset className="form-group">
                     <input
                       type="text"
                       className="form-control form-control-lg"
+                      name="title"
                       placeholder="Article Title"
                     />
                   </fieldset>
@@ -20,6 +46,7 @@ export default function Page() {
                     <input
                       type="text"
                       className="form-control"
+                      name="description"
                       placeholder="What's this article about?"
                     />
                   </fieldset>
@@ -27,25 +54,41 @@ export default function Page() {
                     <textarea
                       className="form-control"
                       rows="8"
+                      name="body"
                       placeholder="Write your article (in markdown)"
                     ></textarea>
                   </fieldset>
-                  <fieldset className="form-group">
+
+                  {/* <fieldset className="form-group">
                     <input
                       type="text"
                       className="form-control"
                       placeholder="Enter tags"
+                      value={tag}
+                      onChange={(event) => setTag(event.target.value)}
                     />
                     <div className="tag-list">
-                      <span className="tag-default tag-pill">
-                        {" "}
-                        <i className="ion-close-round"></i> tag{" "}
-                      </span>
+                      {tags.map((tag) => (
+                        <span className="tag-default tag-pill">
+                          {" "}
+                          <i
+                            id={tag}
+                            className="ion-close-round"
+                            onClick={() => deleteTag(tag)}
+                          ></i>{" "}
+                          {tag}{" "}
+                        </span>
+                      ))}
                     </div>
-                  </fieldset>
+                  </fieldset> */}
+
+                  {/* <button type="button" onClick={() => addTag(tag)}>
+                    タグを追加
+                  </button> */}
+
                   <button
                     className="btn btn-lg pull-xs-right btn-primary"
-                    type="button"
+                    type="submit"
                   >
                     Publish Article
                   </button>

--- a/src/app/lib/actions.js
+++ b/src/app/lib/actions.js
@@ -5,7 +5,7 @@ import { cookies } from "next/headers";
 export async function createArticle(tags, state, formData) {
   // console.log(tags);
   // console.log(formData);
-  console.log(formData.get("title"));
+  // console.log(formData.get("title"));
   try {
     const response = await fetch(`http://api:3000/api/articles`, {
       method: "POST",
@@ -22,8 +22,34 @@ export async function createArticle(tags, state, formData) {
         },
       }),
     });
+    console.log("記事の作成に成功しました");
   } catch (error) {
-    console.log("記事の生成に失敗しました");
+    console.log("記事の作成に失敗しました");
+    // return error;
+  }
+}
+
+export async function updateArticle(tags, slug, state, formData) {
+  console.log(tags);
+  try {
+    const response = await fetch(`http://api:3000/api/articles/${slug}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${cookies().get("session").value}`,
+        "Content-type": "application/json",
+      },
+      body: JSON.stringify({
+        article: {
+          title: formData.get("title"),
+          description: formData.get("description"),
+          body: formData.get("body"),
+          tagList: tags,
+        },
+      }),
+    });
+    console.log("記事の更新に成功しました");
+  } catch (error) {
+    console.log("記事の更新に失敗しました");
     // return error;
   }
 }


### PR DESCRIPTION
## 実施タスク
記事を編集できるようにする fixes #35

## 実施内容
- updateArticleメソッドを追加
- フォームからArticleをUpdateできるように変更
- Articleページにeditボタンを追加

## その他 / 備考
タグの更新はAPI側で実装していなかったので、フォームごと削除した