### PR TITLE
:sparkles: 認可の実装 fixes #39

### DIFF
--- a/src/app/article/[slug]/page.jsx
+++ b/src/app/article/[slug]/page.jsx
@@ -1,10 +1,12 @@
 import { fetchArticle } from "@/app/lib/data";
 import DeleteArticle from "@/app/ui/article/delete-article";
+import { cookies } from "next/headers";
 
 export default async function Page({ params }) {
   const slug = params.slug;
   const articleData = await fetchArticle({ slug: slug });
   const article = articleData.article;
+  const user = cookies().get("username");
   return (
     <>
       <div className="article-page">
@@ -22,13 +24,17 @@ export default async function Page({ params }) {
                 </a>
                 <span className="date">January 20th</span>
               </div>
-              <a
-                href={`/editor/${slug}`}
-                class="btn btn-sm btn-outline-secondary"
-              >
-                <i class="ion-edit"></i> Edit Article
-              </a>
-              <DeleteArticle slug={slug} />
+              {user && user.value == article.author.username && (
+                <>
+                  <a
+                    href={`/editor/${slug}`}
+                    class="btn btn-sm btn-outline-secondary"
+                  >
+                    <i class="ion-edit"></i> Edit Article
+                  </a>
+                  <DeleteArticle slug={slug} />
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/src/app/lib/auth.js
+++ b/src/app/lib/auth.js
@@ -23,6 +23,12 @@ export async function authenticate(state, formData) {
       maxAge: 60 * 60 * 24 * 7, // One week
       path: "/",
     });
+    const username = data.user.username;
+    cookies().set("username", username, {
+      httpOnly: true,
+      maxAge: 60 * 60 * 24 * 7, // One week
+      path: "/",
+    });
     return data;
   } catch (error) {
     console.log(error);
@@ -41,6 +47,7 @@ export async function authenticated() {
 export async function unauthenticate() {
   try {
     cookies().delete("session");
+    cookies().delete("username");
   } catch (error) {
     console.log("ログアウトエラー");
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,25 @@
+import { NextResponse, NextRequest } from "next/server";
+
+// 引数をjsでどう書くかわからないので、このファイルだけtsになった
+export default function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  console.log("middlewareが読み込まれました");
+  const user = request.cookies.get("username");
+  console.log(user);
+
+  // redirect
+  if (pathname === "/editor" && !user) {
+    return NextResponse.redirect(new URL("/", request.url));
+  }
+  if (pathname.startsWith("/editor/") && !user) {
+    const slug = pathname.split("/")[2];
+    return NextResponse.redirect(new URL(`/article/${slug}`, request.url));
+  }
+
+  // マッチしなかったら、そのまま表示
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/editor", "/editor/:slug*"],
+};

--- a/src/next.config.js
+++ b/src/next.config.js
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -13,6 +13,8 @@
         "react-dom": "^18"
       },
       "devDependencies": {
+        "@types/node": "20.11.5",
+        "@types/react": "18.2.48",
         "eslint": "^8",
         "eslint-config-next": "14.0.4"
       }
@@ -329,6 +331,38 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+      "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.11",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.2.48",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.48.tgz",
+      "integrity": "sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
       "dev": true
     },
     "node_modules/@typescript-eslint/parser": {
@@ -854,6 +888,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3512,6 +3552,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/src/package.json
+++ b/src/package.json
@@ -9,11 +9,13 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "14.0.4",
     "react": "^18",
-    "react-dom": "^18",
-    "next": "14.0.4"
+    "react-dom": "^18"
   },
   "devDependencies": {
+    "@types/node": "20.11.5",
+    "@types/react": "18.2.48",
     "eslint": "^8",
     "eslint-config-next": "14.0.4"
   }


### PR DESCRIPTION
## 実施タスク
認可の実装 fixes #39

## 実施内容
- middleware.tsを追加して、認可の実装
- login時にusernameをcookiesに格納するように変更
- article/:slugページでuserが存在しない場合はeditとdeleteのリンクを表示しないように変更

## その他 / 備考
なし