### PR TITLE
:sparkles: お気に入りの実装 fixes #43

### DIFF
--- a/src/app/lib/actions.js
+++ b/src/app/lib/actions.js
@@ -1,6 +1,7 @@
 "use server";
 
 import { cookies } from "next/headers";
+import { revalidatePath } from "next/cache";
 
 export async function createArticle(tags, state, formData) {
   // console.log(tags);
@@ -66,4 +67,23 @@ export async function deleteArticle(slug) {
   } catch (error) {
     console.log("記事の削除に失敗しました");
   }
+}
+
+export async function favorite(slug, pathname) {
+  try {
+    const response = await fetch(
+      `http://api:3000/api/articles/${slug}/favorite`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${cookies().get("session").value}`,
+        },
+      }
+    );
+    console.log("お気に入り登録に成功しました");
+  } catch (error) {
+    console.log("お気に入り登録に失敗しました");
+  }
+
+  revalidatePath(pathname); // revalidatePathを指定することで、次にそのパスにアクセスしたときに再読み込みを行う
 }

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,4 +1,5 @@
 import { fetchArticles } from "@/app/lib/data";
+import Favorite from "@/app/ui/favorite/favorite";
 
 export default async function Page() {
   const articlesData = await fetchArticles({});
@@ -42,9 +43,7 @@ export default async function Page() {
                       </a>
                       <span className="date">January 20th</span>
                     </div>
-                    <button className="btn btn-outline-primary btn-sm pull-xs-right">
-                      <i className="ion-heart"></i> {article.favoritesCount}
-                    </button>
+                    <Favorite article={article} />
                   </div>
                   <a href={`/article/${article.slug}`} className="preview-link">
                     <h1>{article.title}</h1>

--- a/src/app/ui/favorite/favorite.jsx
+++ b/src/app/ui/favorite/favorite.jsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { favorite } from "@/app/lib/actions";
+import { usePathname } from "next/navigation";
+
+export default function Favorite({ article }) {
+  console.log("aaa");
+  const pathname = usePathname();
+  return (
+    <>
+      <button
+        className="btn btn-outline-primary btn-sm pull-xs-right"
+        onClick={() => favorite(article.slug, pathname)}
+      >
+        <i className="ion-heart"></i> {article.favoritesCount}
+      </button>
+    </>
+  );
+}


### PR DESCRIPTION
## 実施タスク
お気に入りの実装 fixes #43

## 実施内容
- お気に入りができるように変更
- お気に入り登録した後で、元居たページを再読み込みするためにrevalidateを設定

## その他 / 備考
なし