### PR TITLE
:sparkles: お気に入り解除機能を追加 fixes #44

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -1,3 +1,10 @@
 .nav-link {
   cursor: pointer;
 }
+
+.btn-outline-primary-hover {
+  color: #fff;
+  background-color: #5cb85c;
+  border-color: #5cb85c;
+  text-decoration: none;
+}

--- a/src/app/lib/actions.js
+++ b/src/app/lib/actions.js
@@ -87,3 +87,22 @@ export async function favorite(slug, pathname) {
 
   revalidatePath(pathname); // revalidatePathを指定することで、次にそのパスにアクセスしたときに再読み込みを行う
 }
+
+export async function unfavorite(slug, pathname) {
+  try {
+    const response = await fetch(
+      `http://api:3000/api/articles/${slug}/favorite`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${cookies().get("session").value}`,
+        },
+      }
+    );
+    console.log("お気に入り解除に成功しました");
+  } catch (error) {
+    console.log("お気に入り解除に失敗しました");
+  }
+
+  revalidatePath(pathname); // revalidatePathを指定することで、次にそのパスにアクセスしたときに再読み込みを行う
+}

--- a/src/app/lib/data.js
+++ b/src/app/lib/data.js
@@ -40,10 +40,18 @@ export async function fetchArticles({
     url = `http://api:3000/api/articles?limit=${limit}&offset=${offset}`;
   }
 
+  let session;
+  if (cookies().get("session")) {
+    session = cookies().get("session").value;
+  }
+
   try {
     const response = await fetch(url, {
       method: "GET",
       cache: "no-store",
+      headers: {
+        Authorization: `Bearer ${session}`,
+      },
     });
     // console.log(response);
     const data = await response.json();

--- a/src/app/profile/[username]/page.jsx
+++ b/src/app/profile/[username]/page.jsx
@@ -1,4 +1,5 @@
 import { fetchArticles } from "@/app/lib/data";
+import Favorite from "@/app/ui/favorite/favorite";
 
 export default async function Page({ params }) {
   const articlesData = await fetchArticles({
@@ -67,9 +68,7 @@ export default async function Page({ params }) {
                       </a>
                       <span className="date">January 20th</span>
                     </div>
-                    <button className="btn btn-outline-primary btn-sm pull-xs-right">
-                      <i className="ion-heart"></i> {article.favoritesCount}
-                    </button>
+                    <Favorite article={article} />
                   </div>
                   <a href={`/article/${article.slug}`} className="preview-link">
                     <h1>{article.title}</h1>

--- a/src/app/ui/favorite/favorite.jsx
+++ b/src/app/ui/favorite/favorite.jsx
@@ -1,19 +1,32 @@
 "use client";
 
-import { favorite } from "@/app/lib/actions";
+import { favorite, unfavorite } from "@/app/lib/actions";
 import { usePathname } from "next/navigation";
 
 export default function Favorite({ article }) {
-  console.log("aaa");
   const pathname = usePathname();
-  return (
-    <>
-      <button
-        className="btn btn-outline-primary btn-sm pull-xs-right"
-        onClick={() => favorite(article.slug, pathname)}
-      >
-        <i className="ion-heart"></i> {article.favoritesCount}
-      </button>
-    </>
-  );
+
+  if (article.favorited) {
+    return (
+      <>
+        <button
+          className="btn btn-outline-primary-hover btn-sm pull-xs-right"
+          onClick={() => unfavorite(article.slug, pathname)}
+        >
+          <i className="ion-heart"></i> {article.favoritesCount}
+        </button>
+      </>
+    );
+  } else {
+    return (
+      <>
+        <button
+          className="btn btn-outline-primary btn-sm pull-xs-right"
+          onClick={() => favorite(article.slug, pathname)}
+        >
+          <i className="ion-heart"></i> {article.favoritesCount}
+        </button>
+      </>
+    );
+  }
 }


### PR DESCRIPTION
## 実施タスク
お気に入り解除機能を追加 fixes #44

## 実施内容
- お気に入り解除機能を追加
- お気に入りしているときはボタンが緑色になるように変更
- お気に入りしているときは解除、していないときは登録ができるように変更
- profileページでもお気に入り/解除ができるように変更

## その他 / 備考
- realworld_apiのarticles_controllerのindexがcertificateされていなかったので修正