### PR TITLE
:sparkles: ページネーションの追加 fixes #53

### DIFF
--- a/src/app/lib/data.js
+++ b/src/app/lib/data.js
@@ -25,19 +25,18 @@ export async function fetchArticles({
   favorited,
   limit = 20,
   offset = 0,
+  page = 1,
 }) {
-  console.log(author);
-
   let url;
 
   if (tag) {
-    url = `http://api:3000/api/articles?tag=${tag}&limit=${limit}&offset=${offset}`;
+    url = `http://api:3000/api/articles?tag=${tag}&limit=${limit}&offset=${offset}&page=${page}`;
   } else if (author) {
-    url = `http://api:3000/api/articles?author=${author}&limit=${limit}&offset=${offset}`;
+    url = `http://api:3000/api/articles?author=${author}&limit=${limit}&offset=${offset}&page=${page}`;
   } else if (favorited) {
-    url = `http://api:3000/api/articles?favorited=${favorited}&limit=${limit}&offset=${offset}`;
+    url = `http://api:3000/api/articles?favorited=${favorited}&limit=${limit}&offset=${offset}&page=${page}`;
   } else {
-    url = `http://api:3000/api/articles?limit=${limit}&offset=${offset}`;
+    url = `http://api:3000/api/articles?limit=${limit}&offset=${offset}&page=${page}`;
   }
 
   let session;
@@ -55,7 +54,7 @@ export async function fetchArticles({
     });
     // console.log(response);
     const data = await response.json();
-    console.log(data);
+    // console.log(data);
     return data;
   } catch (error) {
     console.log(error);

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,11 +1,17 @@
 import { fetchArticles } from "@/app/lib/data";
 import Favorite from "@/app/ui/favorite/favorite";
 import Link from "next/link";
+import Pagination from "@/app/ui/pagination";
+import { headers } from "next/headers";
 
-export default async function Page() {
-  const articlesData = await fetchArticles({});
+export default async function Page({ searchParams }) {
+  const pathname = headers().get("x-pathname") || "";
+  const page = searchParams["page"];
+  const limit = searchParams["limit"] || 20;
+  const articlesData = await fetchArticles({ page: page });
   const articles = articlesData.articles;
   const articlesCount = articlesData.articlesCount;
+  const maxPage = Math.ceil(articlesCount / limit);
   return (
     <>
       <div className="home-page">
@@ -64,18 +70,7 @@ export default async function Page() {
                 </div>
               ))}
 
-              <ul className="pagination">
-                <li className="page-item active">
-                  <Link className="page-link" href="">
-                    1
-                  </Link>
-                </li>
-                <li className="page-item">
-                  <Link className="page-link" href="">
-                    2
-                  </Link>
-                </li>
-              </ul>
+              <Pagination pathname={pathname} page={page} maxPage={maxPage} />
             </div>
           </div>
         </div>

--- a/src/app/profile/[username]/page.jsx
+++ b/src/app/profile/[username]/page.jsx
@@ -1,12 +1,20 @@
 import { fetchArticles } from "@/app/lib/data";
 import Favorite from "@/app/ui/favorite/favorite";
 import Link from "next/link";
+import Pagination from "@/app/ui/pagination";
+import { headers } from "next/headers";
 
-export default async function Page({ params }) {
+export default async function Page({ params, searchParams }) {
+  const pathname = headers().get("x-pathname") || "";
+  const page = searchParams["page"];
+  const limit = searchParams["limit"] || 20;
   const articlesData = await fetchArticles({
     author: params.username,
+    page: page,
   });
   const articles = articlesData.articles;
+  const articlesCount = articlesData.articlesCount;
+  const maxPage = Math.ceil(articlesCount / limit);
   return (
     <>
       <div className="profile-page">
@@ -86,18 +94,7 @@ export default async function Page({ params }) {
                 </div>
               ))}
 
-              <ul className="pagination">
-                <li className="page-item active">
-                  <Link className="page-link" href="">
-                    1
-                  </Link>
-                </li>
-                <li className="page-item">
-                  <Link className="page-link" href="">
-                    2
-                  </Link>
-                </li>
-              </ul>
+              <Pagination pathname={pathname} page={page} maxPage={maxPage} />
             </div>
           </div>
         </div>

--- a/src/app/ui/pagination.jsx
+++ b/src/app/ui/pagination.jsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+
+export default function Pagination({ pathname, page = 1, maxPage }) {
+  function pageComponent() {
+    const items = [];
+
+    for (let p = 1; p <= maxPage; p++) {
+      if (p == page) {
+        items.push(
+          <li className="page-item active">
+            <Link className="page-link" href={`${pathname}?page=${p}`}>
+              {p}
+            </Link>
+          </li>
+        );
+      } else {
+        items.push(
+          <li className="page-item">
+            <Link className="page-link" href={`${pathname}?page=${p}`}>
+              {p}
+            </Link>
+          </li>
+        );
+      }
+    }
+    return <>{items}</>;
+  }
+
+  return (
+    <>
+      <ul className="pagination">{pageComponent()}</ul>
+    </>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,7 +5,10 @@ export default function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   console.log("middlewareが読み込まれました");
   const user = request.cookies.get("username");
-  console.log(user);
+
+  // headerに現在のpathを設定
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-pathname", pathname);
 
   // redirect
   if (pathname === "/editor" && !user) {
@@ -16,10 +19,14 @@ export default function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL(`/article/${slug}`, request.url));
   }
 
-  // マッチしなかったら、そのまま表示
-  return NextResponse.next();
+  // マッチしなかったら表示
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
 }
 
-export const config = {
-  matcher: ["/editor", "/editor/:slug*"],
-};
+// export const config = {
+//   matcher: ["/editor", "/editor/:slug*"],
+// };


### PR DESCRIPTION
## 実施タスク
ページネーションの追加 fixes #53

## 実施内容
- page変数があるときは、参照してfetchするように変更
- SCでpathnameを使えるように、middleware.tsを修正
- paginationをコンポーネント化
  - pathname, page, maxPageを渡して機能するように変更
- articleCountとlimitからmaxPageを算出する処理を追加

## その他 / 備考
articlesCountが、そのページの記事数のみの値になっていたので、全体の記事数を返すようにrails apiを修正。