### PR TITLE
Feature/#58 improve favorite speed

### DIFF
--- a/src/app/lib/actions.js
+++ b/src/app/lib/actions.js
@@ -2,6 +2,7 @@
 
 import { cookies } from "next/headers";
 import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
 
 export async function createArticle(tags, slug, state, formData) {
   try {
@@ -24,6 +25,8 @@ export async function createArticle(tags, slug, state, formData) {
   } catch (error) {
     console.log("記事の作成に失敗しました");
   }
+
+  redirect("/");
 }
 
 export async function updateArticle(tags, slug, state, formData) {
@@ -48,6 +51,8 @@ export async function updateArticle(tags, slug, state, formData) {
   } catch (error) {
     console.log("記事の更新に失敗しました");
   }
+
+  redirect(`/`);
 }
 
 export async function deleteArticle(slug) {
@@ -80,7 +85,7 @@ export async function favorite(slug, pathname) {
     console.log("お気に入り登録に失敗しました");
   }
 
-  revalidatePath(pathname); // revalidatePathを指定することで、次にそのパスにアクセスしたときに再読み込みを行う
+  // revalidatePath(pathname); // revalidatePathを指定することで、次にそのパスにアクセスしたときに再読み込みを行う
 }
 
 export async function unfavorite(slug, pathname) {
@@ -99,5 +104,5 @@ export async function unfavorite(slug, pathname) {
     console.log("お気に入り解除に失敗しました");
   }
 
-  revalidatePath(pathname); // revalidatePathを指定することで、次にそのパスにアクセスしたときに再読み込みを行う
+  // revalidatePath(pathname); // revalidatePathを指定することで、次にそのパスにアクセスしたときに再読み込みを行う
 }

--- a/src/app/lib/actions.js
+++ b/src/app/lib/actions.js
@@ -1,7 +1,6 @@
 "use server";
 
 import { cookies } from "next/headers";
-import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 export async function createArticle(tags, slug, state, formData) {
@@ -69,7 +68,7 @@ export async function deleteArticle(slug) {
   }
 }
 
-export async function favorite(slug, pathname) {
+export async function favorite(slug) {
   try {
     const response = await fetch(
       `http://api:3000/api/articles/${slug}/favorite`,
@@ -81,14 +80,14 @@ export async function favorite(slug, pathname) {
       }
     );
     console.log("お気に入り登録に成功しました");
+    return true;
   } catch (error) {
     console.log("お気に入り登録に失敗しました");
+    return false;
   }
-
-  // revalidatePath(pathname); // revalidatePathを指定することで、次にそのパスにアクセスしたときに再読み込みを行う
 }
 
-export async function unfavorite(slug, pathname) {
+export async function unfavorite(slug) {
   try {
     const response = await fetch(
       `http://api:3000/api/articles/${slug}/favorite`,
@@ -100,9 +99,9 @@ export async function unfavorite(slug, pathname) {
       }
     );
     console.log("お気に入り解除に成功しました");
+    return true;
   } catch (error) {
     console.log("お気に入り解除に失敗しました");
+    return false;
   }
-
-  // revalidatePath(pathname); // revalidatePathを指定することで、次にそのパスにアクセスしたときに再読み込みを行う
 }

--- a/src/app/ui/favorite/favorite.jsx
+++ b/src/app/ui/favorite/favorite.jsx
@@ -1,24 +1,33 @@
 "use client";
 
 import { favorite, unfavorite } from "@/app/lib/actions";
-import { usePathname } from "next/navigation";
 import { useState } from "react";
 
 export default function Favorite({ article }) {
-  const pathname = usePathname();
   let [favoritesCount, setFavoritesCount] = useState(article.favoritesCount);
   let [favorited, setFavorited] = useState(article.favorited);
+
+  async function applyFavorite(diff) {
+    setFavoritesCount(favoritesCount + diff);
+    setFavorited(!favorited);
+    let isOk;
+    if (diff == +1) {
+      isOk = await favorite(article.slug);
+    } else if (diff == -1) {
+      isOk = await unfavorite(article.slug);
+    }
+    if (!isOk) {
+      setFavoritesCount(favoritesCount);
+      setFavorited(favorited);
+    }
+  }
 
   if (favorited) {
     return (
       <>
         <button
           className="btn btn-outline-primary-hover btn-sm pull-xs-right"
-          onClick={() => {
-            setFavoritesCount(favoritesCount - 1);
-            setFavorited(false);
-            unfavorite(article.slug, pathname);
-          }}
+          onClick={() => applyFavorite(-1)}
         >
           <i className="ion-heart"></i> {favoritesCount}
         </button>
@@ -29,11 +38,7 @@ export default function Favorite({ article }) {
       <>
         <button
           className="btn btn-outline-primary btn-sm pull-xs-right"
-          onClick={() => {
-            setFavoritesCount(favoritesCount + 1);
-            setFavorited(true);
-            favorite(article.slug, pathname);
-          }}
+          onClick={() => applyFavorite(+1)}
         >
           <i className="ion-heart"></i> {favoritesCount}
         </button>

--- a/src/app/ui/favorite/favorite.jsx
+++ b/src/app/ui/favorite/favorite.jsx
@@ -2,18 +2,25 @@
 
 import { favorite, unfavorite } from "@/app/lib/actions";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
 
 export default function Favorite({ article }) {
   const pathname = usePathname();
+  let [favoritesCount, setFavoritesCount] = useState(article.favoritesCount);
+  let [favorited, setFavorited] = useState(article.favorited);
 
-  if (article.favorited) {
+  if (favorited) {
     return (
       <>
         <button
           className="btn btn-outline-primary-hover btn-sm pull-xs-right"
-          onClick={() => unfavorite(article.slug, pathname)}
+          onClick={() => {
+            setFavoritesCount(favoritesCount - 1);
+            setFavorited(false);
+            unfavorite(article.slug, pathname);
+          }}
         >
-          <i className="ion-heart"></i> {article.favoritesCount}
+          <i className="ion-heart"></i> {favoritesCount}
         </button>
       </>
     );
@@ -22,9 +29,13 @@ export default function Favorite({ article }) {
       <>
         <button
           className="btn btn-outline-primary btn-sm pull-xs-right"
-          onClick={() => favorite(article.slug, pathname)}
+          onClick={() => {
+            setFavoritesCount(favoritesCount + 1);
+            setFavorited(true);
+            favorite(article.slug, pathname);
+          }}
         >
-          <i className="ion-heart"></i> {article.favoritesCount}
+          <i className="ion-heart"></i> {favoritesCount}
         </button>
       </>
     );

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,6 +3,7 @@ import { NextResponse, NextRequest } from "next/server";
 // 引数をjsでどう書くかわからないので、このファイルだけtsになった
 export default function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  console.log(`${pathname}でmiddlewareを読み込み中`);
   const user = request.cookies.get("username");
 
   // headerに現在のpathを設定
@@ -26,6 +27,15 @@ export default function middleware(request: NextRequest) {
   });
 }
 
-// export const config = {
-//   matcher: ["/editor", "/editor/:slug*"],
-// };
+export const config = {
+  /*
+   * Match all request paths except for the ones starting with:
+   * - api (API routes)
+   * - _next/static (static files)
+   * - _next/image
+   * - assets
+   * - favicon.ico (favicon file)
+   * - sw.js (Service Worker file)
+   */
+  matcher: ["/((?!api|_next/static|_next/image|assets|favicon.ico|sw.js).*)"],
+};


### PR DESCRIPTION
## 実施タスク
お気に入りの速度遅い問題の解消 fixes #58

## 実施内容
- 記事作成、更新後のリダイレクト処理
- お気に入りボタンを押すと、先に見た目だけ反映して、後から整合性をチェックする形に変更
- middlewareがリソースの読み込み時にも走っていたので、ページの読み込み時にだけ走るようにmatcherを設定

## その他 / 備考
なし