### PR TITLE
:sparkles: Loading画面の実装 fixes #60

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -8,3 +8,69 @@
   border-color: #5cb85c;
   text-decoration: none;
 }
+
+/* スクロールバーを常に表示 */
+html {
+  overflow-y: scroll;
+}
+
+/* ローディング */
+.loader,
+.loader:before,
+.loader:after {
+  background: #999999;
+  -webkit-animation: load1 1s infinite ease-in-out;
+  animation: load1 1s infinite ease-in-out;
+  width: 1em;
+  height: 4em;
+}
+.loader {
+  color: #999999;
+  text-indent: -9999em;
+  margin: 88px auto;
+  position: relative;
+  font-size: 11px;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
+}
+.loader:before,
+.loader:after {
+  position: absolute;
+  top: 0;
+  content: "";
+}
+.loader:before {
+  left: -1.5em;
+  -webkit-animation-delay: -0.32s;
+  animation-delay: -0.32s;
+}
+.loader:after {
+  left: 1.5em;
+}
+@-webkit-keyframes load1 {
+  0%,
+  80%,
+  100% {
+    box-shadow: 0 0;
+    height: 4em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 5em;
+  }
+}
+@keyframes load1 {
+  0%,
+  80%,
+  100% {
+    box-shadow: 0 0;
+    height: 4em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 5em;
+  }
+}

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,19 +1,13 @@
-import { headers } from "next/headers";
-import { fetchArticles } from "@/app/lib/data";
-import { getMaxPage } from "@/app/lib/calculate";
+import { Suspense } from "react";
 import Banner from "@/app/ui/top/banner";
 import FeedToggle from "@/app/ui/articles/feed/feed-toggle";
 import Feed from "@/app/ui/articles/feed/feed";
-import Pagination from "@/app/ui/articles/feed/pagination";
+import Loading from "@/app/ui/articles/feed/loading";
 
 export default async function Page({ searchParams }) {
-  const pathname = headers().get("x-pathname") || "";
   const page = searchParams["page"];
-  const articlesData = await fetchArticles({ page: page });
-  const maxPage = getMaxPage({
-    articlesCount: articlesData.articlesCount,
-    limit: searchParams["limit"],
-  });
+  const limit = searchParams["limit"];
+  const offset = searchParams["offset"];
   return (
     <>
       <div className="home-page">
@@ -27,9 +21,9 @@ export default async function Page({ searchParams }) {
                 </ul>
               </div>
 
-              <Feed articles={articlesData.articles} />
-
-              <Pagination pathname={pathname} page={page} maxPage={maxPage} />
+              <Suspense fallback={<Loading />}>
+                <Feed page={page} limit={limit} offset={offset} />
+              </Suspense>
             </div>
           </div>
         </div>

--- a/src/app/profile/[username]/page.jsx
+++ b/src/app/profile/[username]/page.jsx
@@ -1,21 +1,12 @@
-import { headers } from "next/headers";
-import { fetchArticles } from "@/app/lib/data";
-import { getMaxPage } from "@/app/lib/calculate";
+import { Suspense } from "react";
 import FeedToggle from "@/app/ui/articles/feed/feed-toggle";
 import Feed from "@/app/ui/articles/feed/feed";
-import Pagination from "@/app/ui/articles/feed/pagination";
+import Loading from "@/app/ui/articles/feed/loading";
 
 export default async function Page({ params, searchParams }) {
-  const pathname = headers().get("x-pathname") || "";
   const page = searchParams["page"];
-  const articlesData = await fetchArticles({
-    author: params.username,
-    page: page,
-  });
-  const maxPage = getMaxPage({
-    articlesCount: articlesData.articlesCount,
-    limit: searchParams["limit"],
-  });
+  const limit = searchParams["limit"];
+  const offset = searchParams["offset"];
   return (
     <>
       <div className="profile-page">
@@ -44,9 +35,9 @@ export default async function Page({ params, searchParams }) {
                 </ul>
               </div>
 
-              <Feed articles={articlesData.articles} />
-
-              <Pagination pathname={pathname} page={page} maxPage={maxPage} />
+              <Suspense fallback={<Loading />}>
+                <Feed page={page} limit={limit} offset={offset} />
+              </Suspense>
             </div>
           </div>
         </div>

--- a/src/app/ui/articles/article/article-content.jsx
+++ b/src/app/ui/articles/article/article-content.jsx
@@ -8,7 +8,9 @@ export default function ArticleContent({ article }) {
             <p>{article.body}</p>
             <ul className="tag-list">
               {article.tagList.map((tag) => (
-                <li className="tag-default tag-pill tag-outline">{tag}</li>
+                <li className="tag-default tag-pill tag-outline" key={tag}>
+                  {tag}
+                </li>
               ))}
             </ul>
           </div>

--- a/src/app/ui/articles/feed/feed-content.jsx
+++ b/src/app/ui/articles/feed/feed-content.jsx
@@ -9,7 +9,9 @@ export default function FeedContent({ article }) {
         <span>Read more...</span>
         <ul className="tag-list">
           {article.tagList.map((tag) => (
-            <li className="tag-default tag-pill tag-outline">{tag}</li>
+            <li className="tag-default tag-pill tag-outline" key={tag}>
+              {tag}
+            </li>
           ))}
         </ul>
       </Link>

--- a/src/app/ui/articles/feed/feed.jsx
+++ b/src/app/ui/articles/feed/feed.jsx
@@ -1,13 +1,24 @@
-import Link from "next/link";
+import { headers } from "next/headers";
+import { fetchArticles } from "@/app/lib/data";
+import { getMaxPage } from "@/app/lib/calculate";
 import ArticleMeta from "@/app/ui/articles/article-meta";
 import Favorite from "@/app/ui/favorite/favorite";
 import FeedContent from "@/app/ui/articles/feed/feed-content";
+import Pagination from "@/app/ui/articles/feed/pagination";
 
-export default function Feed({ articles }) {
+export default async function Feed({ page, limit, offset }) {
+  const pathname = headers().get("x-pathname") || "";
+  const articlesData = await fetchArticles({ page: page });
+  const articles = articlesData.articles;
+  const maxPage = getMaxPage({
+    articlesCount: articlesData.articlesCount,
+    limit: limit,
+  });
+
   return (
     <>
       {articles.map((article) => (
-        <div className="article-preview">
+        <div className="article-preview" key={article.slug}>
           <div className="article-meta">
             <ArticleMeta article={article} />
             <Favorite article={article} />
@@ -16,6 +27,8 @@ export default function Feed({ articles }) {
           <FeedContent article={article} />
         </div>
       ))}
+
+      <Pagination pathname={pathname} page={page} maxPage={maxPage} />
     </>
   );
 }

--- a/src/app/ui/articles/feed/loading.jsx
+++ b/src/app/ui/articles/feed/loading.jsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <>
+      <p className="loader">Loading...</p>
+    </>
+  );
+}

--- a/src/app/ui/articles/form/article-form.jsx
+++ b/src/app/ui/articles/form/article-form.jsx
@@ -60,7 +60,7 @@ export default function ArticleForm({ action, useTags, slug = "" }) {
                 />
                 <div className="tag-list">
                   {tags.map((tag) => (
-                    <span className="tag-default tag-pill">
+                    <span className="tag-default tag-pill" key={tag}>
                       <i
                         id={tag}
                         className="ion-close-round"


### PR DESCRIPTION
## 実施タスク
Loading画面の実装 fixes #60

## 実施内容
- SuspenseでFeedを囲うことで、data fetchする前に静的な部分を表示
- Feedコンポーネントの中にPaginaionコンポーネントを移動
- Loading用のCSSを設定
- map関数を使って表示しているところのkeyを指定(これをしないとproductionモードで起動したときにエラーを吐く)
- 常にスクロールバーを表示するようにCSSを修正

## その他 / 備考
なし